### PR TITLE
Update protos to recent CometBFT in main, with RFC 106 and skip_extension_signing

### DIFF
--- a/cometbft/src/vote/sign_vote.rs
+++ b/cometbft/src/vote/sign_vote.rs
@@ -10,6 +10,7 @@ pub struct SignVoteRequest {
     pub vote: Vote,
     /// Chain ID
     pub chain_id: chain::Id,
+    pub sign_extension: bool,
 }
 
 impl SignVoteRequest {
@@ -59,7 +60,12 @@ mod v1 {
 
             let chain_id = value.chain_id.try_into()?;
 
-            Ok(SignVoteRequest { vote, chain_id })
+            let sign_extension = value.sign_extension;
+            Ok(SignVoteRequest {
+                vote,
+                chain_id,
+                sign_extension,
+            })
         }
     }
 
@@ -68,6 +74,7 @@ mod v1 {
             RawSignVoteRequest {
                 vote: Some(value.vote.into()),
                 chain_id: value.chain_id.as_str().to_owned(),
+                sign_extension: value.sign_extension,
             }
         }
     }
@@ -113,7 +120,11 @@ mod v1beta1 {
 
             let chain_id = value.chain_id.try_into()?;
 
-            Ok(SignVoteRequest { vote, chain_id })
+            Ok(SignVoteRequest {
+                vote,
+                chain_id,
+                sign_extension: true,
+            })
         }
     }
 
@@ -209,6 +220,7 @@ mod tests {
         let request = SignVoteRequest {
             vote,
             chain_id: ChainId::from_str("test_chain_id").unwrap(),
+            sign_extension: false,
         };
 
         // Option 1 using bytes:
@@ -294,6 +306,7 @@ mod tests {
         let request = SignVoteRequest {
             vote,
             chain_id: ChainId::from_str("test_chain_id").unwrap(),
+            sign_extension: false,
         };
 
         let got = request.into_signable_vec();
@@ -479,6 +492,7 @@ mod tests {
             let want = SignVoteRequest {
                 vote,
                 chain_id: ChainId::from_str("test_chain_id").unwrap(),
+                sign_extension: false,
             };
             let got =
                 <SignVoteRequest as Protobuf<RawSignVoteRequest>>::decode_vec(&encoded).unwrap();
@@ -534,6 +548,7 @@ mod tests {
                 let svr = SignVoteRequest {
                     vote,
                     chain_id: ChainId::from_str("test_chain_id").unwrap(),
+                    sign_extension: false,
                 };
                 let mut got = vec![];
                 let _have = Protobuf::<RawSignVoteRequest>::encode(svr.clone(), &mut got);

--- a/cometbft/src/vote/sign_vote.rs
+++ b/cometbft/src/vote/sign_vote.rs
@@ -10,7 +10,8 @@ pub struct SignVoteRequest {
     pub vote: Vote,
     /// Chain ID
     pub chain_id: chain::Id,
-    pub sign_extension: bool,
+    /// Whether to skip signing the extension bytes.
+    pub skip_extension_signing: bool,
 }
 
 impl SignVoteRequest {
@@ -60,11 +61,12 @@ mod v1 {
 
             let chain_id = value.chain_id.try_into()?;
 
-            let sign_extension = value.sign_extension;
+            let skip_extension_signing = value.skip_extension_signing;
+
             Ok(SignVoteRequest {
                 vote,
                 chain_id,
-                sign_extension,
+                skip_extension_signing,
             })
         }
     }
@@ -74,7 +76,7 @@ mod v1 {
             RawSignVoteRequest {
                 vote: Some(value.vote.into()),
                 chain_id: value.chain_id.as_str().to_owned(),
-                sign_extension: value.sign_extension,
+                skip_extension_signing: value.skip_extension_signing,
             }
         }
     }
@@ -123,7 +125,7 @@ mod v1beta1 {
             Ok(SignVoteRequest {
                 vote,
                 chain_id,
-                sign_extension: true,
+                skip_extension_signing: false,
             })
         }
     }
@@ -220,7 +222,7 @@ mod tests {
         let request = SignVoteRequest {
             vote,
             chain_id: ChainId::from_str("test_chain_id").unwrap(),
-            sign_extension: false,
+            skip_extension_signing: false,
         };
 
         // Option 1 using bytes:
@@ -306,7 +308,7 @@ mod tests {
         let request = SignVoteRequest {
             vote,
             chain_id: ChainId::from_str("test_chain_id").unwrap(),
-            sign_extension: false,
+            skip_extension_signing: false,
         };
 
         let got = request.into_signable_vec();
@@ -492,7 +494,7 @@ mod tests {
             let want = SignVoteRequest {
                 vote,
                 chain_id: ChainId::from_str("test_chain_id").unwrap(),
-                sign_extension: false,
+                skip_extension_signing: false,
             };
             let got =
                 <SignVoteRequest as Protobuf<RawSignVoteRequest>>::decode_vec(&encoded).unwrap();
@@ -548,7 +550,7 @@ mod tests {
                 let svr = SignVoteRequest {
                     vote,
                     chain_id: ChainId::from_str("test_chain_id").unwrap(),
-                    sign_extension: false,
+                    skip_extension_signing: false,
                 };
                 let mut got = vec![];
                 let _have = Protobuf::<RawSignVoteRequest>::encode(svr.clone(), &mut got);

--- a/cometbft/src/vote/sign_vote.rs
+++ b/cometbft/src/vote/sign_vote.rs
@@ -550,7 +550,7 @@ mod tests {
                 let svr = SignVoteRequest {
                     vote,
                     chain_id: ChainId::from_str("test_chain_id").unwrap(),
-                    skip_extension_signing: false,
+                    skip_extension_signing: true,
                 };
                 let mut got = vec![];
                 let _have = Protobuf::<RawSignVoteRequest>::encode(svr.clone(), &mut got);

--- a/proto/src/cometbft.rs
+++ b/proto/src/cometbft.rs
@@ -152,5 +152,5 @@ pub mod version {
 
 pub mod meta {
     pub const REPOSITORY: &str = "https://github.com/cometbft/cometbft";
-    pub const COMMITISH: &str = "b80055e35bebe4db605c9eb5249d852e82b9f02c";
+    pub const COMMITISH: &str = "cb177fed831f74090ecbce9a90c3cdb280900fd4";
 }

--- a/proto/src/cometbft.rs
+++ b/proto/src/cometbft.rs
@@ -152,5 +152,5 @@ pub mod version {
 
 pub mod meta {
     pub const REPOSITORY: &str = "https://github.com/cometbft/cometbft";
-    pub const COMMITISH: &str = "cb177fed831f74090ecbce9a90c3cdb280900fd4";
+    pub const COMMITISH: &str = "ec21d4d2b867476d6e65f824f2207cdb59843286";
 }

--- a/proto/src/cometbft.rs
+++ b/proto/src/cometbft.rs
@@ -152,5 +152,5 @@ pub mod version {
 
 pub mod meta {
     pub const REPOSITORY: &str = "https://github.com/cometbft/cometbft";
-    pub const COMMITISH: &str = "v1.0.0-alpha.1";
+    pub const COMMITISH: &str = "b80055e35bebe4db605c9eb5249d852e82b9f02c";
 }

--- a/proto/src/prost/cometbft.abci.v1.rs
+++ b/proto/src/prost/cometbft.abci.v1.rs
@@ -422,6 +422,7 @@ pub struct CheckTxResponse {
     pub gas_wanted: i64,
     #[prost(int64, tag = "6")]
     pub gas_used: i64,
+    /// nondeterministic
     #[prost(message, repeated, tag = "7")]
     pub events: ::prost::alloc::vec::Vec<Event>,
     #[prost(string, tag = "8")]
@@ -504,7 +505,9 @@ pub struct VerifyVoteExtensionResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizeBlockResponse {
-    /// set of block events emmitted as part of executing the block
+    /// set of block events emitted as part of executing the block
+    ///
+    /// nondeterministic
     #[prost(message, repeated, tag = "1")]
     pub events: ::prost::alloc::vec::Vec<Event>,
     /// the result of executing each transaction including the events
@@ -646,7 +649,7 @@ pub struct VoteInfo {
     #[prost(enumeration = "super::super::types::v1::BlockIdFlag", tag = "3")]
     pub block_id_flag: i32,
 }
-/// ExtendedVoteInfo extends VoteInfo with the vote extentions (non-deterministic).
+/// ExtendedVoteInfo extends VoteInfo with the vote extensions (non-deterministic).
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtendedVoteInfo {
@@ -1031,7 +1034,7 @@ pub mod abci_service_server {
             tonic::Response<super::ProcessProposalResponse>,
             tonic::Status,
         >;
-        /// ExtendVote extends a vote with application-injected data (vote extentions).
+        /// ExtendVote extends a vote with application-injected data (vote extensions).
         async fn extend_vote(
             &self,
             request: tonic::Request<super::ExtendVoteRequest>,

--- a/proto/src/prost/cometbft.abci.v1beta1.rs
+++ b/proto/src/prost/cometbft.abci.v1beta1.rs
@@ -108,7 +108,7 @@ pub struct RequestQuery {
     #[prost(bool, tag = "4")]
     pub prove: bool,
 }
-/// RequestBeginBlock indicates the beginning of commiting the block.
+/// RequestBeginBlock indicates the beginning of committing the block.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestBeginBlock {
@@ -362,7 +362,7 @@ pub struct ResponseCheckTx {
     #[prost(int64, tag = "10")]
     pub priority: i64,
     /// mempool_error is set by CometBFT.
-    /// ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+    /// ABCI applications creating a ResponseCheckTX should not set mempool_error.
     #[prost(string, tag = "11")]
     pub mempool_error: ::prost::alloc::string::String,
 }

--- a/proto/src/prost/cometbft.abci.v1beta2.rs
+++ b/proto/src/prost/cometbft.abci.v1beta2.rs
@@ -81,7 +81,7 @@ pub struct RequestInitChain {
     #[prost(int64, tag = "6")]
     pub initial_height: i64,
 }
-/// RequestBeginBlock indicates the beginning of commiting the block.
+/// RequestBeginBlock indicates the beginning of committing the block.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestBeginBlock {
@@ -245,7 +245,7 @@ pub struct ResponseCheckTx {
     #[prost(int64, tag = "10")]
     pub priority: i64,
     /// mempool_error is set by CometBFT.
-    /// ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+    /// ABCI applications creating a ResponseCheckTX should not set mempool_error.
     #[prost(string, tag = "11")]
     pub mempool_error: ::prost::alloc::string::String,
 }
@@ -395,7 +395,7 @@ pub struct EventAttribute {
     #[prost(bool, tag = "3")]
     pub index: bool,
 }
-/// ExtendedVoteInfo extends VoteInfo with the vote extentions (non-deterministic).
+/// ExtendedVoteInfo extends VoteInfo with the vote extensions (non-deterministic).
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtendedVoteInfo {

--- a/proto/src/prost/cometbft.abci.v1beta3.rs
+++ b/proto/src/prost/cometbft.abci.v1beta3.rs
@@ -345,7 +345,7 @@ pub mod response_verify_vote_extension {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseFinalizeBlock {
-    /// set of block events emmitted as part of executing the block
+    /// set of block events emitted as part of executing the block
     #[prost(message, repeated, tag = "1")]
     pub events: ::prost::alloc::vec::Vec<super::v1beta2::Event>,
     /// the result of executing each transaction including the events
@@ -376,7 +376,7 @@ pub struct VoteInfo {
     #[prost(enumeration = "super::super::types::v1beta1::BlockIdFlag", tag = "3")]
     pub block_id_flag: i32,
 }
-/// ExtendedVoteInfo extends VoteInfo with the vote extentions (non-deterministic).
+/// ExtendedVoteInfo extends VoteInfo with the vote extensions (non-deterministic).
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtendedVoteInfo {
@@ -563,7 +563,7 @@ pub mod abci_server {
             tonic::Response<super::super::v1beta2::ResponseProcessProposal>,
             tonic::Status,
         >;
-        /// ExtendVote extends a vote with application-injected data (vote extentions).
+        /// ExtendVote extends a vote with application-injected data (vote extensions).
         async fn extend_vote(
             &self,
             request: tonic::Request<super::RequestExtendVote>,

--- a/proto/src/prost/cometbft.blocksync.v1.rs
+++ b/proto/src/prost/cometbft.blocksync.v1.rs
@@ -34,7 +34,7 @@ pub struct BlockResponse {
     #[prost(message, optional, tag = "2")]
     pub ext_commit: ::core::option::Option<super::super::types::v1::ExtendedCommit>,
 }
-/// Message is an abtract blocksync message.
+/// Message is an abstract blocksync message.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {

--- a/proto/src/prost/cometbft.blocksync.v1beta1.rs
+++ b/proto/src/prost/cometbft.blocksync.v1beta1.rs
@@ -32,7 +32,7 @@ pub struct StatusResponse {
     #[prost(int64, tag = "2")]
     pub base: i64,
 }
-/// Message is an abtract blocksync message.
+/// Message is an abstract blocksync message.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {

--- a/proto/src/prost/cometbft.crypto.v1.rs
+++ b/proto/src/prost/cometbft.crypto.v1.rs
@@ -69,7 +69,7 @@ pub struct DominoOp {
     pub output: ::prost::alloc::string::String,
 }
 /// ProofOp defines an operation used for calculating Merkle root
-/// The data could be arbitrary format, providing nessecary data
+/// The data could be arbitrary format, providing necessary data
 /// for example neighbouring node hash
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/prost/cometbft.privval.v1.rs
+++ b/proto/src/prost/cometbft.privval.v1.rs
@@ -31,8 +31,9 @@ pub struct SignVoteRequest {
     pub vote: ::core::option::Option<super::super::types::v1::Vote>,
     #[prost(string, tag = "2")]
     pub chain_id: ::prost::alloc::string::String,
+    /// if true, the signer may skip signing the extension bytes.
     #[prost(bool, tag = "3")]
-    pub sign_extension: bool,
+    pub skip_extension_signing: bool,
 }
 /// SignedVoteResponse is a response containing a signed vote or an error
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/prost/cometbft.privval.v1.rs
+++ b/proto/src/prost/cometbft.privval.v1.rs
@@ -31,6 +31,8 @@ pub struct SignVoteRequest {
     pub vote: ::core::option::Option<super::super::types::v1::Vote>,
     #[prost(string, tag = "2")]
     pub chain_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "3")]
+    pub sign_extension: bool,
 }
 /// SignedVoteResponse is a response containing a signed vote or an error
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/prost/cometbft.services.block.v1.rs
+++ b/proto/src/prost/cometbft.services.block.v1.rs
@@ -2,7 +2,7 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetByHeightRequest {
-    /// The height of the block requested. If set to 0, the latest height will be returned.
+    /// The height of the block requested.
     #[prost(int64, tag = "1")]
     pub height: i64,
 }
@@ -10,19 +10,6 @@ pub struct GetByHeightRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetByHeightResponse {
-    #[prost(message, optional, tag = "1")]
-    pub block_id: ::core::option::Option<super::super::super::types::v1::BlockId>,
-    #[prost(message, optional, tag = "2")]
-    pub block: ::core::option::Option<super::super::super::types::v1::Block>,
-}
-/// GetLatestRequest is a request for the latest block.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetLatestRequest {}
-/// GetLatestResponse contains the latest block ID and the latest block.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetLatestResponse {
     #[prost(message, optional, tag = "1")]
     pub block_id: ::core::option::Option<super::super::super::types::v1::BlockId>,
     #[prost(message, optional, tag = "2")]
@@ -55,14 +42,6 @@ pub mod block_service_server {
             request: tonic::Request<super::GetByHeightRequest>,
         ) -> std::result::Result<
             tonic::Response<super::GetByHeightResponse>,
-            tonic::Status,
-        >;
-        /// GetLatest retrieves the latest block.
-        async fn get_latest(
-            &self,
-            request: tonic::Request<super::GetLatestRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetLatestResponse>,
             tonic::Status,
         >;
         /// Server streaming response type for the GetLatestHeight method.
@@ -194,52 +173,6 @@ pub mod block_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetByHeightSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/cometbft.services.block.v1.BlockService/GetLatest" => {
-                    #[allow(non_camel_case_types)]
-                    struct GetLatestSvc<T: BlockService>(pub Arc<T>);
-                    impl<
-                        T: BlockService,
-                    > tonic::server::UnaryService<super::GetLatestRequest>
-                    for GetLatestSvc<T> {
-                        type Response = super::GetLatestResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::GetLatestRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as BlockService>::get_latest(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = GetLatestSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/prost/cometbft.services.block_results.v1.rs
+++ b/proto/src/prost/cometbft.services.block_results.v1.rs
@@ -5,39 +5,10 @@ pub struct GetBlockResultsRequest {
     #[prost(int64, tag = "1")]
     pub height: i64,
 }
-/// GetLatestBlockResultsRequest is a request for the BlockResults of the latest block.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetLatestBlockResultsRequest {}
 /// GetBlockResultsResponse contains the block results for the given height.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockResultsResponse {
-    #[prost(int64, tag = "1")]
-    pub height: i64,
-    #[prost(message, repeated, tag = "2")]
-    pub tx_results: ::prost::alloc::vec::Vec<
-        super::super::super::abci::v1::ExecTxResult,
-    >,
-    #[prost(message, repeated, tag = "3")]
-    pub finalize_block_events: ::prost::alloc::vec::Vec<
-        super::super::super::abci::v1::Event,
-    >,
-    #[prost(message, repeated, tag = "4")]
-    pub validator_updates: ::prost::alloc::vec::Vec<
-        super::super::super::abci::v1::ValidatorUpdate,
-    >,
-    #[prost(message, optional, tag = "5")]
-    pub consensus_param_updates: ::core::option::Option<
-        super::super::super::types::v1::ConsensusParams,
-    >,
-    #[prost(bytes = "vec", tag = "6")]
-    pub app_hash: ::prost::alloc::vec::Vec<u8>,
-}
-/// GetLatestBlockResultsResponse contains the block results for the latest block.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetLatestBlockResultsResponse {
     #[prost(int64, tag = "1")]
     pub height: i64,
     #[prost(message, repeated, tag = "2")]
@@ -73,14 +44,6 @@ pub mod block_results_service_server {
             request: tonic::Request<super::GetBlockResultsRequest>,
         ) -> std::result::Result<
             tonic::Response<super::GetBlockResultsResponse>,
-            tonic::Status,
-        >;
-        /// GetLatestBlockResults returns the BlockResults of the latest committed height.
-        async fn get_latest_block_results(
-            &self,
-            request: tonic::Request<super::GetLatestBlockResultsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetLatestBlockResultsResponse>,
             tonic::Status,
         >;
     }
@@ -200,56 +163,6 @@ pub mod block_results_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = GetBlockResultsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/cometbft.services.block_results.v1.BlockResultsService/GetLatestBlockResults" => {
-                    #[allow(non_camel_case_types)]
-                    struct GetLatestBlockResultsSvc<T: BlockResultsService>(pub Arc<T>);
-                    impl<
-                        T: BlockResultsService,
-                    > tonic::server::UnaryService<super::GetLatestBlockResultsRequest>
-                    for GetLatestBlockResultsSvc<T> {
-                        type Response = super::GetLatestBlockResultsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::GetLatestBlockResultsRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as BlockResultsService>::get_latest_block_results(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = GetLatestBlockResultsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/prost/cometbft.types.v1.rs
+++ b/proto/src/prost/cometbft.types.v1.rs
@@ -585,7 +585,7 @@ pub struct Block {
     #[prost(message, optional, tag = "4")]
     pub last_commit: ::core::option::Option<Commit>,
 }
-/// EventDataRoundState is emmitted with each new round step.
+/// EventDataRoundState is emitted with each new round step.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventDataRoundState {

--- a/proto/src/prost/cometbft.types.v1beta1.rs
+++ b/proto/src/prost/cometbft.types.v1beta1.rs
@@ -526,7 +526,7 @@ pub struct Block {
     #[prost(message, optional, tag = "4")]
     pub last_commit: ::core::option::Option<Commit>,
 }
-/// EventDataRoundState is emmitted with each new round step.
+/// EventDataRoundState is emitted with each new round step.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventDataRoundState {

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -6,7 +6,7 @@ pub const COMETBFT_REPO: &str = "https://github.com/cometbft/cometbft";
 /// - Tag: `v1.0.0`
 /// - Branch: `main`
 /// - Commit ID (full length): `d7d0ffea13c60c98b812d243ba5a2c375f341c15`
-pub const COMETBFT_COMMITISH: &str = "b80055e35bebe4db605c9eb5249d852e82b9f02c";
+pub const COMETBFT_COMMITISH: &str = "cb177fed831f74090ecbce9a90c3cdb280900fd4";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -6,7 +6,7 @@ pub const COMETBFT_REPO: &str = "https://github.com/cometbft/cometbft";
 /// - Tag: `v1.0.0`
 /// - Branch: `main`
 /// - Commit ID (full length): `d7d0ffea13c60c98b812d243ba5a2c375f341c15`
-pub const COMETBFT_COMMITISH: &str = "v1.0.0-alpha.1";
+pub const COMETBFT_COMMITISH: &str = "b80055e35bebe4db605c9eb5249d852e82b9f02c";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -6,7 +6,7 @@ pub const COMETBFT_REPO: &str = "https://github.com/cometbft/cometbft";
 /// - Tag: `v1.0.0`
 /// - Branch: `main`
 /// - Commit ID (full length): `d7d0ffea13c60c98b812d243ba5a2c375f341c15`
-pub const COMETBFT_COMMITISH: &str = "cb177fed831f74090ecbce9a90c3cdb280900fd4";
+pub const COMETBFT_COMMITISH: &str = "ec21d4d2b867476d6e65f824f2207cdb59843286";
 
 /// Predefined custom attributes for message annotations
 const PRIMITIVE_ENUM: &str = r#"#[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]"#;


### PR DESCRIPTION
Since CometBFT 1.0.0-alpha.1, there were a couple of significant changes to proto files:

1. `GetLatest*` methods were removed from the data companion API as per [RFC 106](https://github.com/cometbft/cometbft/pull/1545).
2. A `skip_extension_signing` flag was added to `cometbft.privval.v1`.

Regenerate `cometbft-proto` from a recent cometbft commit that includes the changes.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
