### PR TITLE
Fix typos and grammatical errors in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ structures in cometbft-proto.
     single release (currently at 1.0.0-alpha.1) and generate all protobuf
     structures at once.
   * In the new versioned module structure corresponding to the CometBFT 1.0
-    protobuf packages, modules represending protocol domains come to the top
+    protobuf packages, modules representing protocol domains come to the top
     level, e.g. `crate::abci`, `crate::types`. Each of these has a `v1` module
     corresponding to the protobufs released in 1.0.0, and possibly a series of
     `v1beta1`, `v1beta2`, ... modules with earlier revisions of the protocol,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Changes with multiple classifications should be doubly included (eg. a bug fix
 that is also a breaking change should be recorded under both).
 
 Breaking changes are further subdivided according to the APIs/users they impact.
-Any change that effects multiple APIs/users should be recorded multiply - for
+Any change that affects multiple APIs/users should be recorded multiply - for
 instance, a change to some core protocol data structure might need to be
 reflected both as breaking the core protocol but also breaking any APIs where
 core data structures are exposed.


### PR DESCRIPTION
This pull request fixes two typos in the text:

1. Corrected "represending" to "representing".
2. Fixed "effects" to "affects" for grammatical accuracy.