### PR TITLE
Add codespace field to Tx sync and async Response

### DIFF
--- a/.changelog/unreleased/breaking-changes/1382-add-codespace-error.md
+++ b/.changelog/unreleased/breaking-changes/1382-add-codespace-error.md
@@ -1,0 +1,2 @@
+- Add the `codespace` field to the Tx sync and async broadcast `Response`
+  ([\#1382](https://github.com/informalsystems/tendermint-rs/issues/1382))

--- a/rpc/src/endpoint/broadcast/tx_async.rs
+++ b/rpc/src/endpoint/broadcast/tx_async.rs
@@ -38,6 +38,9 @@ impl<S: Dialect> crate::SimpleRequest<S> for Request {
 /// Response from either an async or sync transaction broadcast request.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Response {
+    /// Code space
+    pub codespace: String,
+
     /// Code
     pub code: Code,
 

--- a/rpc/src/endpoint/broadcast/tx_sync.rs
+++ b/rpc/src/endpoint/broadcast/tx_sync.rs
@@ -38,6 +38,9 @@ impl<S: Dialect> crate::SimpleRequest<S> for Request {
 /// Response from either an async or sync transaction broadcast request.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Response {
+    /// Code space
+    pub codespace: String,
+
     /// Code
     pub code: Code,
 


### PR DESCRIPTION
Port-of: https://github.com/cometbft/tendermint-rs/pull/1383

This PR adds the codespace field to Tx sync and async Response which gives additional information on the source of the error.
