### PR TITLE
rpc: Make `rpc::Client` and `SubscriptionClient` traits `?Send` under…

### DIFF
--- a/.changelog/unreleased/improvements/1385-rpc-make-client-send-wasm32.md
+++ b/.changelog/unreleased/improvements/1385-rpc-make-client-send-wasm32.md
@@ -1,0 +1,2 @@
+- `[tendermint-rpc]` Make `rpc::Client` and `SubscriptionClient` traits `?Send` under `wasm32` target.
+  ([\#1385](https://github.com/informalsystems/tendermint-rs/issues/1385))

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,6 +1,6 @@
 //! cometbft-proto library gives the developer access to the CometBFT proto-defined structs.
 
-#![cfg_attr(not(any(feature = "grpc-server", feature = "grpc-client")), no_std)]
+#![cfg_attr(not(any(feature = "grpc-server")), no_std)]
 #![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant)]
 #![forbid(unsafe_code)]

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -45,7 +45,8 @@ use crate::{
 /// [`SubscriptionClient`] trait.
 ///
 /// [`SubscriptionClient`]: trait.SubscriptionClient.html
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Client {
     /// `/abci_info`: get information about the ABCI application.
     async fn abci_info(&self) -> Result<abci::response::Info, Error> {

--- a/rpc/src/client/subscription.rs
+++ b/rpc/src/client/subscription.rs
@@ -19,7 +19,8 @@ use crate::{
 
 /// A client that exclusively provides [`Event`] subscription capabilities,
 /// without any other RPC method support.
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SubscriptionClient {
     /// `/subscribe`: subscribe to receive events produced by the given query.
     async fn subscribe(&self, query: Query) -> Result<Subscription, Error>;


### PR DESCRIPTION
… `wasm32` target

Port-of: https://github.com/cometbft/tendermint-rs/pull/1386
