### PR TITLE
rpc: Allow empty JSON object value for consensus_param_updates in

### DIFF
--- a/.changelog/unreleased/bug-fixes/77-allow-empty-consensus-params-updates.md
+++ b/.changelog/unreleased/bug-fixes/77-allow-empty-consensus-params-updates.md
@@ -1,0 +1,5 @@
+- `[cometbft-rpc]` Deserialize an empty JSON object as `None` for the
+  `consensus_param_updates` field in the `/block_results` response. Deserialize
+  version in consensus params as `None` if it is an empty object, null or not
+  found.
+  ([\#77](https://github.com/cometbft/cometbft-rs/issues/77))

--- a/cometbft/src/consensus/params.rs
+++ b/cometbft/src/consensus/params.rs
@@ -2,7 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{block, evidence, prelude::*, public_key};
+use crate::{
+    block, evidence, prelude::*, public_key, serializers::allow_empty_object::allow_empty_object,
+};
 
 /// All consensus-relevant parameters that can be adjusted by the ABCI app.
 ///
@@ -15,8 +17,9 @@ pub struct Params {
     pub evidence: evidence::Params,
     /// Parameters limiting the types of public keys validators can use.
     pub validator: ValidatorParams,
-    /// The ABCI application version.
-    #[serde(skip)] // FIXME: kvstore /genesis returns '{}' instead of '{app_version: "0"}'
+    /// The ABCI application version. Will default to None if not present.
+    #[serde(default, deserialize_with = "allow_empty_object")]
+    //#[serde(skip)]
     pub version: Option<VersionParams>,
     /// Parameters specific to the Application Blockchain Interface.
     ///
@@ -41,7 +44,7 @@ pub struct ValidatorParams {
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
 pub struct VersionParams {
     /// The ABCI application version.
-    #[serde(with = "crate::serializers::from_str")]
+    #[serde(with = "crate::serializers::from_str", alias = "app_version")]
     pub app: u64,
 }
 

--- a/cometbft/src/serializers.rs
+++ b/cometbft/src/serializers.rs
@@ -7,6 +7,7 @@
 //! risk.
 pub use cometbft_proto::serializers::*;
 
+pub mod allow_empty_object;
 pub mod apphash;
 pub mod apphash_base64;
 pub mod hash;

--- a/cometbft/src/serializers/allow_empty_object.rs
+++ b/cometbft/src/serializers/allow_empty_object.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize `null` or an empty object `{}` as `None`.
+pub fn allow_empty_object<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(
+        untagged,
+        deny_unknown_fields,
+        expecting = "object, empty object or null"
+    )]
+    enum Helper<T> {
+        Data(T),
+        Empty {},
+        Null,
+    }
+
+    match Helper::deserialize(deserializer) {
+        Ok(Helper::Data(data)) => Ok(Some(data)),
+        Ok(Helper::Empty {} | Helper::Null) => Ok(None),
+        Err(e) => Err(e),
+    }
+}

--- a/rpc/src/endpoint/block_results.rs
+++ b/rpc/src/endpoint/block_results.rs
@@ -1,5 +1,6 @@
 //! `/block_results` endpoint JSON-RPC wrapper
 
+use cometbft::serializers::allow_empty_object::allow_empty_object;
 use cometbft::{abci, block, consensus, serializers, validator, AppHash};
 use serde::{Deserialize, Serialize};
 
@@ -78,6 +79,7 @@ pub struct Response {
     pub validator_updates: Vec<validator::Update>,
 
     /// New consensus params (might be explicit null)
+    #[serde(deserialize_with = "allow_empty_object")]
     pub consensus_param_updates: Option<consensus::Params>,
 
     /// Merkle hash of the application state
@@ -98,6 +100,7 @@ pub mod v0_34 {
     use crate::dialect::v0_34::Event;
     use crate::prelude::*;
     use crate::{dialect, serializers};
+    use cometbft::serializers::allow_empty_object::allow_empty_object;
     use cometbft::{block, consensus, validator};
     use serde::{Deserialize, Serialize};
 
@@ -121,6 +124,7 @@ pub mod v0_34 {
         pub validator_updates: Vec<validator::Update>,
 
         /// New consensus params (might be explicit null)
+        #[serde(deserialize_with = "allow_empty_object")]
         pub consensus_param_updates: Option<consensus::Params>,
     }
 

--- a/rpc/tests/kvstore_fixtures/v0_37.rs
+++ b/rpc/tests/kvstore_fixtures/v0_37.rs
@@ -1,3 +1,5 @@
+use cometbft::consensus::params::VersionParams;
+
 use super::*;
 
 #[test]
@@ -665,7 +667,10 @@ fn incoming_fixtures() {
                     result.genesis.consensus_params.validator.pub_key_types[0],
                     cometbft::public_key::Algorithm::Ed25519
                 );
-                assert!(result.genesis.consensus_params.version.is_none());
+                assert_eq!(
+                    result.genesis.consensus_params.version,
+                    Some(VersionParams { app: 0 })
+                );
                 assert!(
                     result
                         .genesis

--- a/rpc/tests/kvstore_fixtures/v0_38.rs
+++ b/rpc/tests/kvstore_fixtures/v0_38.rs
@@ -1,3 +1,5 @@
+use cometbft::consensus::params::VersionParams;
+
 use super::*;
 
 #[test]
@@ -665,7 +667,10 @@ fn incoming_fixtures() {
                     result.genesis.consensus_params.validator.pub_key_types[0],
                     cometbft::public_key::Algorithm::Ed25519
                 );
-                assert!(result.genesis.consensus_params.version.is_none());
+                assert_eq!(
+                    result.genesis.consensus_params.version,
+                    Some(VersionParams { app: 0 })
+                );
                 assert!(
                     result
                         .genesis


### PR DESCRIPTION
../block_results response

Port-of: https://github.com/cometbft/tendermint-rs/pull/1441

Closes #77
