### PR TITLE
fix: Bump `prost` and `prost-types` to latest versions in cometbft crate

### DIFF
--- a/.changelog/unreleased/breaking-changes/83-fix-prost-version.md
+++ b/.changelog/unreleased/breaking-changes/83-fix-prost-version.md
@@ -1,5 +1,0 @@
-- `[cometbft]` Bump `prost` and `prost-types` to their latest versions in the `cometbft` crate.
-  This was missed in [#64](https://github.com/cometbft/cometbft-rs/pull/64),
-  which only updated the two dependencies in `tendermint-rpc`, leading to duplicate versions
-  of both crates to be present in the dependency graph.
-  ([#83](https://github.com/cometbft/cometbft-rs/pull/83))

--- a/.changelog/unreleased/dependencies/84-fix-prost-version.md
+++ b/.changelog/unreleased/dependencies/84-fix-prost-version.md
@@ -1,0 +1,6 @@
+- `[cometbft]` Bump `prost` and `prost-types` to their latest versions in the
+  `cometbft` crate. This was missed in
+  [#64](https://github.com/cometbft/cometbft-rs/pull/64), which only updated the
+  two dependencies in `cometbft-rpc`, leading to duplicate versions of both
+  crates to be present in the dependency graph.
+  ([\#84](https://github.com/cometbft/cometbft-rs/issues/84))


### PR DESCRIPTION
Port-of: https://github.com/cometbft/tendermint-rs/pull/1446

Closes https://github.com/cometbft/cometbft-rs/issues/84