### PR TITLE
Fix new clippy warnings on Rust 1.80

### DIFF
--- a/cometbft/src/abci/request/apply_snapshot_chunk.rs
+++ b/cometbft/src/abci/request/apply_snapshot_chunk.rs
@@ -61,7 +61,7 @@ cometbft_old_pb_modules! {
         ) -> Result<Self, Self::Error> {
             Ok(Self {
                 index: apply_snapshot_chunk.index,
-                chunk: apply_snapshot_chunk.chunk.into(),
+                chunk: apply_snapshot_chunk.chunk,
                 sender: apply_snapshot_chunk.sender,
             })
         }

--- a/light-client-verifier/src/operations/voting_power.rs
+++ b/light-client-verifier/src/operations/voting_power.rs
@@ -204,7 +204,7 @@ impl NonAbsentCommitVote {
         chain_id: &chain::Id,
     ) -> Option<Result<Self, VerificationError>> {
         let (validator_address, timestamp, signature) = match commit_sig {
-            CommitSig::BlockIdFlagAbsent { .. } => return None,
+            CommitSig::BlockIdFlagAbsent => return None,
             CommitSig::BlockIdFlagCommit {
                 validator_address,
                 timestamp,
@@ -259,10 +259,10 @@ impl NonAbsentCommitVotes {
     /// isn’t critical for correctness.  It’s a matter of performance to avoid
     /// reallocations.
     ///
-    /// Note: As of protocol 0.38, maximum length of the sign bytes is `115 + (N
-    /// > 13) + N` where `N` is the length of the chain id.  Chain id can be at
-    /// most 50 bytes (see [`tendermint::chain::id::MAX_LEN`]) thus the largest
-    /// buffer we’ll ever need is 166 bytes long.
+    /// Note: As of protocol 0.38, maximum length of the sign bytes is `115 + (N > 13) + N`
+    /// where `N` is the length of the chain id.
+    /// Chain id can be at most 50 bytes (see [`tendermint::chain::id::MAX_LEN`])
+    /// thus the largest buffer we’ll ever need is 166 bytes long.
     const SIGN_BYTES_INITIAL_CAPACITY: usize = 166;
 
     pub fn new(signed_header: &SignedHeader) -> Result<Self, VerificationError> {

--- a/light-client/src/components/scheduler.rs
+++ b/light-client/src/components/scheduler.rs
@@ -79,10 +79,10 @@ pub fn basic_bisecting_schedule(
 /// following specification.
 ///
 /// - i) If `latest_verified_height == current_height` and `latest_verified_height < target_height`
-/// then `current_height < scheduled_height <= target_height`.
+///   then `current_height < scheduled_height <= target_height`.
 ///
 /// - ii) If `latest_verified_height < current_height` and `latest_verified_height < target_height`
-/// then `latest_verified_height < scheduled_height < current_height`.
+///   then `latest_verified_height < scheduled_height < current_height`.
 ///
 /// - iii) If `latest_verified_height = target_height` then `scheduled_height == target_height`.
 ///

--- a/pbt-gen/src/lib.rs
+++ b/pbt-gen/src/lib.rs
@@ -4,8 +4,7 @@
 //! Conditions for inclusion in this crate are:
 //!
 //! 1. The utilities are relatively general.
-//! 2. The utilities don't rely on any code internal to the other crates of
-//! this repository.
+//! 2. The utilities don't rely on any code internal to the other crates of this repository.
 //!
 //! The each module of this crate (and the module's dependencies) are guarded by
 //! a feature, documented along with the module.

--- a/rpc/src/client/transport/router.rs
+++ b/rpc/src/client/transport/router.rs
@@ -9,7 +9,7 @@ use crate::{client::subscription::SubscriptionTx, error::Error, event::Event, pr
 pub type SubscriptionQuery = String;
 pub type SubscriptionId = String;
 
-#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
+#[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
 pub type SubscriptionIdRef<'a> = &'a str;
 
 /// Provides a mechanism for tracking [`Subscription`]s and routing [`Event`]s
@@ -28,7 +28,7 @@ pub struct SubscriptionRouter {
 impl SubscriptionRouter {
     /// Publishes the given error to all of the subscriptions to which the
     /// error is relevant, based on the given subscription id query.
-    #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
+    #[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
     pub fn publish_error(&mut self, id: SubscriptionIdRef<'_>, err: Error) -> PublishResult {
         if let Some(query) = self.subscription_query(id).cloned() {
             self.publish(query, Err(err))
@@ -38,7 +38,7 @@ impl SubscriptionRouter {
     }
 
     /// Get the query associated with the given subscription.
-    #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
+    #[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
     fn subscription_query(&self, id: SubscriptionIdRef<'_>) -> Option<&SubscriptionQuery> {
         for (query, subs) in &self.subscriptions {
             if subs.contains_key(id) {
@@ -51,7 +51,7 @@ impl SubscriptionRouter {
 
     /// Publishes the given event to all of the subscriptions to which the
     /// event is relevant, based on the associated query.
-    #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
+    #[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
     pub fn publish_event(&mut self, ev: Event) -> PublishResult {
         self.publish(ev.query.clone(), Ok(ev))
     }
@@ -129,6 +129,7 @@ pub enum PublishResult {
     Success,
     NoSubscribers,
     // All subscriptions for the given query have disconnected.
+    #[cfg_attr(not(feature = "websocket-client"), allow(dead_code))]
     AllDisconnected(String),
 }
 


### PR DESCRIPTION
Port-of: https://github.com/cometbft/tendermint-rs/pull/1451

Closes #90
