### PR TITLE
docs(cometbft): update ABCI links

### DIFF
--- a/cometbft/src/abci/doc/request-applysnapshotchunk.md
+++ b/cometbft/src/abci/doc/request-applysnapshotchunk.md
@@ -18,4 +18,4 @@ because no suitable peers are available), it will reject the snapshot and try
 a different one via `OfferSnapshot`. The application should be prepared to
 reset and accept it or abort as appropriate.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#applysnapshotchunk)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#applysnapshotchunk)

--- a/cometbft/src/abci/doc/request-beginblock.md
+++ b/cometbft/src/abci/doc/request-beginblock.md
@@ -3,4 +3,6 @@ Signals the beginning of a new block.
 Called prior to any [`DeliverTx`]s. The `header` contains the height,
 timestamp, and more -- it exactly matches the CometBFT block header.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#beginblock)
+**This is only called by CometBFT prior to version v0.38.0.**
+
+[ABCI documentation](https://docs.cometbft.com/v0.37/spec/abci/abci++_methods#beginblock)

--- a/cometbft/src/abci/doc/request-checktx.md
+++ b/cometbft/src/abci/doc/request-checktx.md
@@ -8,4 +8,4 @@ transaction in full, but can instead perform lightweight or statateful
 validation (e.g., checking signatures or account balances) instead of more
 expensive checks (like running code in a virtual machine).
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#checktx)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#checktx)

--- a/cometbft/src/abci/doc/request-commit.md
+++ b/cometbft/src/abci/doc/request-commit.md
@@ -1,4 +1,4 @@
 Signals the application that it can write the queued state transitions
 from the block to its state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#commit)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#commit)

--- a/cometbft/src/abci/doc/request-delivertx.md
+++ b/cometbft/src/abci/doc/request-delivertx.md
@@ -1,3 +1,5 @@
 Execute a transaction against the application state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#delivertx)
+**This is only called by CometBFT prior to version v0.38.0.**
+
+[ABCI documentation](https://docs.cometbft.com/v0.37/spec/abci/abci++_methods#delivertx)

--- a/cometbft/src/abci/doc/request-echo.md
+++ b/cometbft/src/abci/doc/request-echo.md
@@ -1,3 +1,3 @@
 Echoes a string to test an ABCI implementation.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#echo)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#echo)

--- a/cometbft/src/abci/doc/request-endblock.md
+++ b/cometbft/src/abci/doc/request-endblock.md
@@ -2,4 +2,6 @@ Signals the end of a block.
 
 Called after all transactions, and prior to each `Commit`.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#endblock)
+**This is only called by CometBFT prior to version v0.38.0.**
+
+[ABCI documentation](https://docs.cometbft.com/v0.37/spec/abci/abci++_methods#endblock)

--- a/cometbft/src/abci/doc/request-extendvote.md
+++ b/cometbft/src/abci/doc/request-extendvote.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_methods.md#extendvote)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#extendvote)

--- a/cometbft/src/abci/doc/request-finalizeblock.md
+++ b/cometbft/src/abci/doc/request-finalizeblock.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_methods.md#finalizeblock)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#finalizeblock)

--- a/cometbft/src/abci/doc/request-flush.md
+++ b/cometbft/src/abci/doc/request-flush.md
@@ -1,3 +1,3 @@
 Indicates that any pending requests should be completed and their responses flushed.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#flush)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#flush)

--- a/cometbft/src/abci/doc/request-info.md
+++ b/cometbft/src/abci/doc/request-info.md
@@ -1,3 +1,3 @@
 Requests information about the application state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#info)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#info)

--- a/cometbft/src/abci/doc/request-initchain.md
+++ b/cometbft/src/abci/doc/request-initchain.md
@@ -1,3 +1,3 @@
 Called on genesis to initialize chain state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#initchain)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#initchain)

--- a/cometbft/src/abci/doc/request-listsnapshots.md
+++ b/cometbft/src/abci/doc/request-listsnapshots.md
@@ -1,3 +1,3 @@
 Asks the application for a list of snapshots.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#listsnapshots)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#listsnapshots)

--- a/cometbft/src/abci/doc/request-loadsnapshotchunk.md
+++ b/cometbft/src/abci/doc/request-loadsnapshotchunk.md
@@ -1,3 +1,3 @@
 Used during state sync to retrieve snapshot chunks from peers.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#loadsnapshotchunk)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#loadsnapshotchunk)

--- a/cometbft/src/abci/doc/request-offersnapshot.md
+++ b/cometbft/src/abci/doc/request-offersnapshot.md
@@ -15,6 +15,6 @@ at the end of snapshot restoration.
 
 See also the `Snapshot` data type and the [ABCI state sync documentation][ssd].
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#offersnapshot)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#offersnapshot)
 
-[ssd]: https://docs.cometbft.com/v1/spec/abci/apps.html#state-sync
+[ssd]: https://docs.cometbft.com/v1.0/explanation/core/state-sync

--- a/cometbft/src/abci/doc/request-prepareproposal.md
+++ b/cometbft/src/abci/doc/request-prepareproposal.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#prepareproposal)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#prepareproposal)

--- a/cometbft/src/abci/doc/request-processproposal.md
+++ b/cometbft/src/abci/doc/request-processproposal.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#processproposal)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#processproposal)

--- a/cometbft/src/abci/doc/request-query.md
+++ b/cometbft/src/abci/doc/request-query.md
@@ -1,3 +1,3 @@
 Queries for data from the application at current or past height.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#query)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#query)

--- a/cometbft/src/abci/doc/request-verifyvoteextension.md
+++ b/cometbft/src/abci/doc/request-verifyvoteextension.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_methods.md#verifyvoteextension)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#verifyvoteextension)

--- a/cometbft/src/abci/doc/response-applysnapshotchunk.md
+++ b/cometbft/src/abci/doc/response-applysnapshotchunk.md
@@ -4,4 +4,4 @@ The application can choose to refetch chunks and/or ban P2P peers as
 appropriate. CometBFT will not do this unless instructed by the
 application.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#applysnapshotchunk)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#applysnapshotchunk)

--- a/cometbft/src/abci/doc/response-beginblock.md
+++ b/cometbft/src/abci/doc/response-beginblock.md
@@ -1,3 +1,5 @@
 Returns events that occurred when beginning a new block.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#beginblock)
+**This is only called by CometBFT prior to version v0.38.0.**
+
+[ABCI documentation](https://docs.cometbft.com/v0.37/spec/abci/abci++_methods#beginblock)

--- a/cometbft/src/abci/doc/response-checktx.md
+++ b/cometbft/src/abci/doc/response-checktx.md
@@ -1,3 +1,3 @@
 Returns the result of checking a transaction for mempool inclusion.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#checktx)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#checktx)

--- a/cometbft/src/abci/doc/response-commit.md
+++ b/cometbft/src/abci/doc/response-commit.md
@@ -1,3 +1,3 @@
 Returns the result of persisting the application state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#commit)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#commit)

--- a/cometbft/src/abci/doc/response-delivertx.md
+++ b/cometbft/src/abci/doc/response-delivertx.md
@@ -1,4 +1,6 @@
 Returns events that occurred while executing a transaction against the
 application state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#delivertx)
+**This is only called by CometBFT prior to version v0.38.0.**
+
+[ABCI documentation](https://docs.cometbft.com/v0.37/spec/abci/abci++_methods#delivertx)

--- a/cometbft/src/abci/doc/response-echo.md
+++ b/cometbft/src/abci/doc/response-echo.md
@@ -1,3 +1,3 @@
 Echoes a string to test an ABCI implementation.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#echo)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#echo)

--- a/cometbft/src/abci/doc/response-endblock.md
+++ b/cometbft/src/abci/doc/response-endblock.md
@@ -1,3 +1,5 @@
 Returns validator updates that occur after the end of a block.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#endblock)
+**This is only called by CometBFT prior to version v0.38.0.**
+
+[ABCI documentation](https://docs.cometbft.com/v0.37/spec/abci/abci++_methods#endblock)

--- a/cometbft/src/abci/doc/response-extendvote.md
+++ b/cometbft/src/abci/doc/response-extendvote.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_methods.md#extendvote)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#extendvote)

--- a/cometbft/src/abci/doc/response-finalizeblock.md
+++ b/cometbft/src/abci/doc/response-finalizeblock.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_methods.md#finalizeblock)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#finalizeblock)

--- a/cometbft/src/abci/doc/response-flush.md
+++ b/cometbft/src/abci/doc/response-flush.md
@@ -1,3 +1,3 @@
 Indicates that all pending requests have been completed with their responses flushed.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#flush)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#flush)

--- a/cometbft/src/abci/doc/response-info.md
+++ b/cometbft/src/abci/doc/response-info.md
@@ -1,3 +1,3 @@
 Returns information about the application state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#info)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#info)

--- a/cometbft/src/abci/doc/response-initchain.md
+++ b/cometbft/src/abci/doc/response-initchain.md
@@ -1,3 +1,3 @@
 Returned on genesis after initializing chain state.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#initchain)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#initchain)

--- a/cometbft/src/abci/doc/response-listsnapshots.md
+++ b/cometbft/src/abci/doc/response-listsnapshots.md
@@ -1,3 +1,3 @@
 Returns a list of local state snapshots.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#listsnapshots)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#listsnapshots)

--- a/cometbft/src/abci/doc/response-loadsnapshotchunk.md
+++ b/cometbft/src/abci/doc/response-loadsnapshotchunk.md
@@ -1,3 +1,3 @@
 Returns a snapshot chunk from the application.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#loadsnapshotchunk)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#loadsnapshotchunk)

--- a/cometbft/src/abci/doc/response-offersnapshot.md
+++ b/cometbft/src/abci/doc/response-offersnapshot.md
@@ -2,6 +2,6 @@ Returns the application's response to a snapshot offer.
 
 See also the [`OfferSnapshot`] data type and the [ABCI state sync documentation][ssd].
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#offersnapshot)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#offersnapshot)
 
-[ssd]: https://docs.cometbft.com/v1/spec/abci/apps.html#state-sync
+[ssd]: https://docs.cometbft.com/v1.0/explanation/core/state-sync

--- a/cometbft/src/abci/doc/response-prepareproposal.md
+++ b/cometbft/src/abci/doc/response-prepareproposal.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#prepareproposal)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#prepareproposal)

--- a/cometbft/src/abci/doc/response-processproposal.md
+++ b/cometbft/src/abci/doc/response-processproposal.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#processproposal)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#processproposal)

--- a/cometbft/src/abci/doc/response-query.md
+++ b/cometbft/src/abci/doc/response-query.md
@@ -1,3 +1,3 @@
 Returns data queried from the application.
 
-[ABCI documentation](https://docs.cometbft.com/v1/spec/abci/abci.html#query)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#query)

--- a/cometbft/src/abci/doc/response-verifyvoteextension.md
+++ b/cometbft/src/abci/doc/response-verifyvoteextension.md
@@ -1,1 +1,1 @@
-[ABCI documentation](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_methods.md#verifyvoteextension)
+[ABCI documentation](https://docs.cometbft.com/v1.0/spec/abci/abci++_methods#verifyvoteextension)


### PR DESCRIPTION
This pull request updates the ABCI documentation links across multiple files in the `cometbft/src/abci/doc` directory to point to the latest version (v1.0) of the CometBFT documentation. Additionally, it adds version-specific notes for methods that are only applicable to CometBFT versions prior to v0.38.0.