### PR TITLE
fix(tools/no-std-check): drop `no_mangle` attr

### DIFF
--- a/tools/no-std-check/src/lib.rs
+++ b/tools/no-std-check/src/lib.rs
@@ -44,7 +44,6 @@ error[E0152]: found duplicate lang item `panic_impl`
  */
 #[cfg(feature = "panic-handler")]
 #[panic_handler]
-#[unsafe(no_mangle)]
 fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }

--- a/tools/no-std-check/src/lib.rs
+++ b/tools/no-std-check/src/lib.rs
@@ -44,7 +44,7 @@ error[E0152]: found duplicate lang item `panic_impl`
  */
 #[cfg(feature = "panic-handler")]
 #[panic_handler]
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }


### PR DESCRIPTION
fixes:

```
error: `#[no_mangle]` cannot be used on internal language items
  --> src/lib.rs:47:1
   |
47 | #[no_mangle]
   | ^^^^^^^^^^^^
48 | fn panic(_info: &PanicInfo) -> ! {
   | -------------------------------- should be the internal language item
   |
   = note: Rustc requires this item to have a specific mangled name.
   = note: If you are trying to prevent mangling to ease debugging, many
   = note: debuggers support a command such as `rbreak rust_begin_unwind` to
   = note: match `.*rust_begin_unwind.*` instead of `break rust_begin_unwind` on a specific name

error: could not compile `no-std-check` (lib) due to 1 previous error
```
