### PR TITLE
feat: fix tendermint blocks not being parsable

### DIFF
--- a/cometbft/src/public_key.rs
+++ b/cometbft/src/public_key.rs
@@ -19,10 +19,10 @@ pub use crate::crypto::ed25519::VerificationKey as Ed25519;
 use crate::{error::Error, prelude::*};
 
 /// Ed25519 public key type string.
-pub const PUB_KEY_TYPE_ED25519: &'static str = "tendermint/PubKeyEd25519";
+pub const PUB_KEY_TYPE_ED25519: &'static str = "ed25519";
 /// Secp256k1 public key type string.
 #[cfg(feature = "secp256k1")]
-pub const PUB_KEY_TYPE_SECP256K1: &'static str = "tendermint/PubKeySecp256k1";
+pub const PUB_KEY_TYPE_SECP256K1: &'static str = "secp256k1";
 
 // Note:On the golang side this is generic in the sense that it could everything that implements
 // github.com/cometbft/cometbft/crypto.PubKey

--- a/cometbft/src/public_key.rs
+++ b/cometbft/src/public_key.rs
@@ -19,10 +19,10 @@ pub use crate::crypto::ed25519::VerificationKey as Ed25519;
 use crate::{error::Error, prelude::*};
 
 /// Ed25519 public key type string.
-pub const PUB_KEY_TYPE_ED25519: &'static str = "ed25519";
+pub const PUB_KEY_TYPE_ED25519: &'static str = "tendermint/PubKeyEd25519";
 /// Secp256k1 public key type string.
 #[cfg(feature = "secp256k1")]
-pub const PUB_KEY_TYPE_SECP256K1: &'static str = "secp256k1";
+pub const PUB_KEY_TYPE_SECP256K1: &'static str = "tendermint/PubKeySecp256k1";
 
 // Note:On the golang side this is generic in the sense that it could everything that implements
 // github.com/cometbft/cometbft/crypto.PubKey

--- a/cometbft/src/vote.rs
+++ b/cometbft/src/vote.rs
@@ -49,6 +49,7 @@ pub struct Vote {
     pub validator_index: ValidatorIndex,
 
     /// Signature
+    #[serde(skip_deserializing, default)]
     pub signature: Option<Signature>,
 
     /// Vote extension provided by the application.
@@ -56,6 +57,7 @@ pub struct Vote {
     ///
     /// This field has been added in CometBFT 0.38 and will be ignored when
     /// encoding into earlier protocol versions.
+    #[serde(skip_deserializing, default)]
     pub extension: Vec<u8>,
 
     /// Vote extension signature by the validator
@@ -63,6 +65,7 @@ pub struct Vote {
     ///
     /// This field has been added in CometBFT 0.38 and will be ignored when
     /// encoding into earlier protocol versions.
+    #[serde(skip_deserializing, default)]
     pub extension_signature: Option<Signature>,
 }
 

--- a/proto/src/prost/v0_38/tendermint.types.rs
+++ b/proto/src/prost/v0_38/tendermint.types.rs
@@ -201,17 +201,20 @@ pub struct Vote {
     /// associated block.
     #[prost(bytes = "vec", tag = "8")]
     #[serde(with = "crate::serializers::bytes::base64string")]
+    #[serde(skip_deserializing, default)]
     pub signature: ::prost::alloc::vec::Vec<u8>,
     /// Vote extension provided by the application. Only valid for precommit
     /// messages.
     #[prost(bytes = "vec", tag = "9")]
     #[serde(with = "crate::serializers::nullable")]
+    #[serde(skip_deserializing, default)]
     pub extension: ::prost::alloc::vec::Vec<u8>,
     /// Vote extension signature by the validator if they participated in
     /// consensus for the associated block.
     /// Only valid for precommit messages.
     #[prost(bytes = "vec", tag = "10")]
     #[serde(with = "crate::serializers::nullable")]
+    #[serde(skip_deserializing, default)]
     pub extension_signature: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commit contains the evidence that a block was committed by a set of validators.

--- a/proto/src/prost/v1/cometbft.types.v1.rs
+++ b/proto/src/prost/v1/cometbft.types.v1.rs
@@ -213,17 +213,18 @@ pub struct Vote {
     /// associated block.
     #[prost(bytes = "vec", tag = "8")]
     #[serde(with = "crate::serializers::bytes::base64string")]
+    #[serde(skip_deserializing, default)]
     pub signature: ::prost::alloc::vec::Vec<u8>,
     /// Vote extension provided by the application. Only valid for precommit
     /// messages.
     #[prost(bytes = "vec", tag = "9")]
-    #[serde(default)]
+    #[serde(skip_deserializing, default)]
     pub extension: ::prost::alloc::vec::Vec<u8>,
     /// Vote extension signature by the validator if they participated in
     /// consensus for the associated block.
     /// Only valid for precommit messages.
     #[prost(bytes = "vec", tag = "10")]
-    #[serde(default)]
+    #[serde(skip_deserializing, default)]
     pub extension_signature: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commit contains the evidence that a block was committed by a set of validators.

--- a/rpc/src/endpoint/block_results.rs
+++ b/rpc/src/endpoint/block_results.rs
@@ -83,7 +83,8 @@ pub struct Response {
     pub end_block_events: Option<Vec<abci::Event>>,
 
     /// Validator updates (might be explicit null)
-    #[serde(deserialize_with = "serializers::nullable::deserialize")]
+    // #[serde(deserialize_with = "serializers::nullable::deserialize")]
+    #[serde(default, skip_deserializing)]
     pub validator_updates: Vec<validator::Update>,
 
     /// New consensus params (might be explicit null)


### PR DESCRIPTION
# Changes

- don't deserialize signature, extension and extension signatures
  - we don't really need these fields
