### PR TITLE
refactor(account): remove unused v1 module after ISA-2025-003 fix

### DIFF
--- a/cometbft/src/account.rs
+++ b/cometbft/src/account.rs
@@ -219,33 +219,6 @@ cometbft_old_pb_modules! {
     }
 }
 
-pub mod v1 {
-    use super::{Id, LENGTH};
-    #[cfg(feature = "secp256k1")]
-    use crate::public_key::PUB_KEY_TYPE_SECP256K1;
-    use crate::{prelude::*, public_key::PUB_KEY_TYPE_ED25519, Error};
-    use digest::Digest;
-    use sha2::Sha256;
-
-    pub fn try_from_type_and_bytes(pub_key_type: &str, pub_key_bytes: &[u8]) -> Result<Id, Error> {
-        if pub_key_type == PUB_KEY_TYPE_ED25519 {
-            let digest = Sha256::digest(pub_key_bytes);
-            return Ok(Id(digest[..LENGTH].try_into().unwrap()));
-        }
-        #[cfg(feature = "secp256k1")]
-        if pub_key_type == PUB_KEY_TYPE_SECP256K1 {
-            use ripemd::Ripemd160;
-
-            let sha_digest = Sha256::digest(pub_key_bytes);
-            let ripemd_digest = Ripemd160::digest(&sha_digest[..]);
-            let mut bytes = [0u8; LENGTH];
-            bytes.copy_from_slice(&ripemd_digest[..LENGTH]);
-            return Ok(Id(bytes));
-        }
-        Err(Error::invalid_key("unknown key".to_string()))
-    }
-}
-
 #[cfg(all(test, feature = "rust-crypto"))]
 mod tests {
     use super::*;

--- a/cometbft/src/validator.rs
+++ b/cometbft/src/validator.rs
@@ -401,7 +401,7 @@ cometbft_old_pb_modules! {
 
 mod v1 {
     use super::{Info, Set, SimpleValidator, Update};
-    use crate::{account, prelude::*, Error, PublicKey};
+    use crate::{account::Id, prelude::*, Error, PublicKey};
     use cometbft_proto::abci::v1::ValidatorUpdate as RawValidatorUpdate;
     use cometbft_proto::types::v1::{
         SimpleValidator as RawSimpleValidator, Validator as RawValidator,
@@ -442,15 +442,11 @@ mod v1 {
 
         fn try_from(value: RawValidator) -> Result<Self, Self::Error> {
             let address = value.address.try_into()?;
-            if account::v1::try_from_type_and_bytes(&value.pub_key_type, &value.pub_key_bytes)?
-                != address
-            {
-                return Err(Error::invalid_validator_address());
-            }
-
             let pub_key =
                 PublicKey::try_from_type_and_bytes(&value.pub_key_type, &value.pub_key_bytes)?;
-
+            if Id::from(pub_key) != address {
+                return Err(Error::invalid_validator_address());
+            }
             Ok(Info {
                 address,
                 pub_key,


### PR DESCRIPTION
## Summary
Removes the unused `account::v1` module after the ISA-2025-003 security fix.

## Changes
- Replaced `account::v1::try_from_type_and_bytes()` with `Id::from(PublicKey)` in validator.rs
- Removed the entire `pub mod v1` from account.rs

## Related
Closes #107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `account::v1` and updates v1 validator conversions to validate addresses via `Id::from(pub_key)` with corresponding import adjustments.
> 
> - **Account (`cometbft/src/account.rs`)**:
>   - Remove legacy `pub mod v1` and its `try_from_type_and_bytes` helper.
> - **Validator (`cometbft/src/validator.rs`)**:
>   - v1 conversions: validate `address` by deriving from parsed `pub_key` using `Id::from(pub_key)`.
>   - Update imports to use `crate::account::Id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f18a4d99a244c8c9eac65036877819bfe794dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->